### PR TITLE
FEAT/13: Default Tab using tab order and not relying on hardcoded "Code" name/title

### DIFF
--- a/example/components/Button/Development.mdx
+++ b/example/components/Button/Development.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Button Component"
 description: "This is the button component code page"
-tab: "Code"
+tab: "Development"
 tabOrder: 1
 publishToStyleGuide: true
 ---

--- a/gatsby-theme-emulsify/gatsby-config.js
+++ b/gatsby-theme-emulsify/gatsby-config.js
@@ -9,23 +9,23 @@ module.exports = ({
   designSystems = [
     {
       name: "System 1",
-      link: "/"
+      link: "/",
     },
     {
       name: "System 2",
-      link: ""
-    }
+      link: "",
+    },
   ],
   siteMetadata = {
     title: "Project Name",
     author: "Your Organization",
-    description: "A Design System Driven by Gatsby"
-  }
+    description: "A Design System Driven by Gatsby",
+  },
 }) => ({
   siteMetadata: {
     ...siteMetadata,
     designSystems,
-    UILibPath
+    UILibPath,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -33,29 +33,29 @@ module.exports = ({
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `components`,
-        path: path.join(basePath, componentLibPath)
-      }
+        path: path.join(basePath, componentLibPath),
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `pages`,
-        path: path.join(basePath, docPagesPath)
-      }
+        path: path.join(basePath, docPagesPath),
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/src`
-      }
+        path: `${__dirname}/src`,
+      },
     },
     {
       resolve: "gatsby-plugin-react-svg",
       options: {
         rule: {
-          include: /assets/
-        }
-      }
+          include: /assets/,
+        },
+      },
     },
     {
       resolve: `gatsby-plugin-mdx`,
@@ -66,15 +66,15 @@ module.exports = ({
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 1200,
-              wrapperStyle: fluidResult =>
-                `flex:${_.round(fluidResult.aspectRatio, 2)};`
-            }
+              wrapperStyle: (fluidResult) =>
+                `flex:${_.round(fluidResult.aspectRatio, 2)};`,
+            },
           },
-          `gatsby-remark-copy-linked-files`
-        ]
-      }
+          `gatsby-remark-copy-linked-files`,
+        ],
+      },
     },
     `gatsby-plugin-sharp`,
-    `gatsby-plugin-theme-ui`
-  ]
+    `gatsby-plugin-theme-ui`,
+  ],
 });

--- a/gatsby-theme-emulsify/gatsby-node.js
+++ b/gatsby-theme-emulsify/gatsby-node.js
@@ -38,20 +38,20 @@ exports.createPages = async ({ actions, graphql }) => {
       }
     `,
     { limit: 1000 }
-  ).then(result => {
+  ).then((result) => {
     if (result.errors) {
       throw result.errors;
     }
 
-    result.data.allMdx.edges.forEach(edge => {
+    result.data.allMdx.edges.forEach((edge) => {
       createPage({
         path: edge.node.fields.slug,
         component: PageLayout,
         context: {
           slug: edge.node.fields.slug,
           collection: edge.node.fields.collection,
-          parentDir: edge.node.fields.parentDir
-        }
+          parentDir: edge.node.fields.parentDir,
+        },
       });
     });
   });
@@ -63,13 +63,13 @@ exports.onCreateNode = async ({ node, actions, getNode }) => {
   if (node.internal.type === `Mdx`) {
     let value = createFilePath({
       node,
-      getNode
+      getNode,
     }).toLowerCase();
     value = value.replace(/\s+/g, "-").toLowerCase();
     createNodeField({
       name: `slug`,
       node,
-      value
+      value,
     });
 
     // For items added to menu, get the parent node.
@@ -80,18 +80,18 @@ exports.onCreateNode = async ({ node, actions, getNode }) => {
       createNodeField({
         node,
         name: `sortOrder`,
-        value: value
+        value: value,
       });
       const parent = getNode(_.get(node, "parent"));
       createNodeField({
         node,
         name: "collection",
-        value: _.get(parent, "sourceInstanceName")
+        value: _.get(parent, "sourceInstanceName"),
       });
       createNodeField({
         node,
         name: "parentDir",
-        value: _.get(parent, "relativeDirectory")
+        value: _.get(parent, "relativeDirectory"),
       });
     }
   }

--- a/gatsby-theme-emulsify/src/components/Molecules/Menus/Menu.component.js
+++ b/gatsby-theme-emulsify/src/components/Molecules/Menus/Menu.component.js
@@ -16,38 +16,12 @@ export default class Menu extends Component {
 
     menu.forEach((item) => {
       let isActive = false;
-      // Components
-      if (item.sourceInstanceName === "components") {
-        // Only add one Components subitem to menu - should be refactored later.
-        if (item.name === "Code") {
-          // Mark the item active if its id is the same as the id of the current page.
-          isActive = item.childMdx.id === id;
-          if (!isActive) {
-            // Also mark the item active if the current page id corresponds to a menu item that shares a prefix with the Code item (sibling).
-            let prefix = item.childMdx.fields.slug.replace("code/", "");
-            let siblings = menu.filter((menuitem) =>
-              menuitem.childMdx
-                ? menuitem.childMdx.id === id &&
-                  menuitem.childMdx.fields.slug.startsWith(prefix)
-                : ""
-            );
-            isActive = siblings.length > 0;
-          }
-          directoryTree.children.push({
-            item: item,
-            active: isActive,
-          });
-        }
-      }
-      // Pages
-      else {
-        if (item.childMdx) {
-          isActive = item.childMdx.id === id;
-          directoryTree.children.push({
-            item: item,
-            active: isActive,
-          });
-        }
+      if (item.childMdx) {
+        isActive = item.childMdx.id === id;
+        directoryTree.children.push({
+          item: item,
+          active: isActive,
+        });
       }
     });
 

--- a/gatsby-theme-emulsify/src/components/Molecules/Menus/MenuComponent.component.js
+++ b/gatsby-theme-emulsify/src/components/Molecules/Menus/MenuComponent.component.js
@@ -17,24 +17,33 @@ export default class MenuComponent extends Component {
     menu.forEach((item) => {
       let isActive = false;
       // Only add one Components subitem to menu - should be refactored later.
-      if (item.name === "Code") {
-        // Mark the item active if its id is the same as the id of the current page.
-        isActive = item.childMdx.id === id;
-        if (!isActive) {
-          // Also mark the item active if the current page id corresponds to a menu item that shares a prefix with the Code item (sibling).
-          let prefix = item.childMdx.fields.slug.replace("code/", "");
-          let siblings = menu.filter((menuitem) =>
-            menuitem.childMdx
-              ? menuitem.childMdx.id === id &&
-                menuitem.childMdx.fields.slug.startsWith(prefix)
-              : ""
-          );
-          isActive = siblings.length > 0;
+      if (item.childMdx) {
+        if (
+          item.sourceInstanceName === "components" &&
+          item.childMdx.frontmatter.tabOrder === 1
+        ) {
+          // Mark the item active if its id is the same as the id of the current page.
+          isActive = item.childMdx.id === id;
+          if (!isActive) {
+            // Also mark the item active if the current page id corresponds to a menu item that shares a prefix with the Code item (sibling).
+            let slashlessPrefix = item.childMdx.fields.slug.slice(0, -1);
+            let prefix = slashlessPrefix.substring(
+              0,
+              slashlessPrefix.lastIndexOf("/")
+            );
+            let siblings = menu.filter((menuitem) =>
+              menuitem.childMdx
+                ? menuitem.childMdx.id === id &&
+                  menuitem.childMdx.fields.slug.startsWith(prefix)
+                : ""
+            );
+            isActive = siblings.length > 0;
+          }
+          directoryTree.children.push({
+            item: item,
+            active: isActive,
+          });
         }
-        directoryTree.children.push({
-          item: item,
-          active: isActive,
-        });
       }
     });
 

--- a/gatsby-theme-emulsify/src/components/Templates/layout.js
+++ b/gatsby-theme-emulsify/src/components/Templates/layout.js
@@ -113,6 +113,7 @@ export const pageQuery = graphql`
           frontmatter {
             title
             tab
+            tabOrder
           }
           fields {
             slug


### PR DESCRIPTION
This PR fixes https://github.com/emulsify-ds/gatsby-theme-emulsify-workspace/issues/13. We were relying on the first tab of a component page to be named "Code" instead of relying on tab order to signify the first page. This PR changes it to use tabOrder. It also removes some extraneous code and makes some prettier fixes.